### PR TITLE
Add missing required python deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,9 @@ pywin32>=306; sys_platform == 'win32'
 numpy>=2.0.0
 opencv-python>=4.10.0
 pyinstaller>=6.0.0
+pandas>=2.2.3
+psutil>=7.0.0
+requests>=2.32.3
+obsws_python>=1.7.2
+httpx>=0.28.1
+tqdm>=4.67.1


### PR DESCRIPTION
## Problem
After a fresh python install, building the recorder has various python errors due to certain called modules not being included in requirements.txt

## Solution
Add these to requirements.txt

## Testing
- [x] Confirmed no module not found errors when running `pip install -r requirements.txt && npm run build && npm run dev`
- [x] Opened settings from the systray & modified some settings